### PR TITLE
Exp clipping z

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ TODO: Make this package *conda* installable...
 For now, there are two options for installation,
 
 ### Option 1: pip
-The first option is to use ``pip+git``. For this method you **MUST** install ``ENTERPRISE`` through conda first. I reccomend installing it with ``enterprise_extensions`` for its additional utility. Follow these steps. This has been verified to work in python versions: 3.9, 3.11, 3.12. You may need to check which version of enterprise gets installed. I suggest using python 3.9, as it has the best compatibility with minimal effort:
+The first option is to use ``pip+git``. For this method you **MUST** install ``ENTERPRISE`` through conda first. We recommend installing it with ``enterprise_extensions`` for its additional utility. Follow these steps. This has been verified to work in python versions: 3.9, 3.11, 3.12. 
 
 ```bash
 conda install -c conda-forge enterprise_extensions
-pip install git+https://github.com/GersbachKa/defiant@main
+pip install git+https://github.com/GersbachKa/defiant
 
 # If you are using VScode for your notebooks, I reccomend you use https://pypi.org/project/vscode-tqdm/ 
 # This fixes a bug in the rendering of notebooks. You will also need ipywidgets

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='DEFIANT (Data-driven Enhanced Frequentist Inference Analysis with Next-gen Techniques)',
     long_description=readme,
     long_description_content_type="text/markdown",
-    version='0.1.2',
+    version='0.1.3',
     author='Kyle A. Gersbach',
     author_email='gersbach.ka@gmail.com',
     url='https://github.com/GersbachKa/defiant/',


### PR DESCRIPTION
Added covariance matrix clipping to the Z matrix products. This can be helpful in extremely noisy data but should be used with caution. Default behavior is identical