### PR TITLE
Reworking the implementation of the OS and PFOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ from defiant import OptimalStatistic
 
 ## Example notebook
 
-As speed, reproducability, and most important: Documentation are all primary concerns with the development of DEFIANT. Frustrated by the inadequate documentation from many packages in PTA science, DEFIANT attempts to be different by being overly documented. As such, a ton of time and care have been put into developing examples for others to copy. The main resource (for now at least) for learning to use DEFIANT is in the notebooks section:
+Speed, reproducability, and most important, documentation, are all primary concerns with the development of DEFIANT. Frustrated by the inadequate documentation from many packages in PTA science, DEFIANT attempts to be different by being overly documented and detailed in every component. As such, a ton of time and care have been put into developing examples for others to copy. The main resource (for now at least) for learning to use DEFIANT is in the notebooks section:
 
 Specifically: [notebooks/many_examples.ipynb](https://github.com/GersbachKa/defiant/blob/main/notebooks/many_examples.ipynb)
 

--- a/defiant/pair_covariance.py
+++ b/defiant/pair_covariance.py
@@ -38,7 +38,7 @@ def _compute_pair_covariance(Z, phi1, phi2, orf, norm_ab, a2_est, use_tqdm, max_
     fact_c = _factored_pair_covariance(Z, phi1, phi2, orf, norm_ab, 
                                        use_tqdm, max_chunk)
     
-    return np.array(( fact_c[0], a2_est*fact_c[1] + a2_est**2*fact_c[2] ))
+    return fact_c[0] + a2_est*fact_c[1] + a2_est**2*fact_c[2]
 
 
 def _compute_mcos_pair_covariance(Z, phi1, phi2, orf, design, 
@@ -91,7 +91,7 @@ def _compute_mcos_pair_covariance(Z, phi1, phi2, orf, design,
 
     fact_c = _factored_pair_covariance(Z, phi1, phi2, cor_pow, norm_ab, 
                                        use_tqdm, max_chunk)
-    return np.array(( fact_c[0], fact_c[1] + fact_c[2] ))
+    return fact_c[0] + fact_c[1] + fact_c[2]
 
 
 # Hidden function which directly calculates the factored pair covariance matrix.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='DEFIANT (Data-driven Enhanced Frequentist Inference Analysis with Next-gen Techniques)',
     long_description=readme,
     long_description_content_type="text/markdown",
-    version='0.1.3',
+    version='0.2.0',
     author='Kyle A. Gersbach',
     author_email='gersbach.ka@gmail.com',
     url='https://github.com/GersbachKa/defiant/',


### PR DESCRIPTION
This pull changes many implementation headaches with Defiant. This cleans unnecessary methods like _compute_os_iteration() in favor of more comprehensive and easy to understand methods like compute_OS().

Other major changes are:
1. An input handler for both the OS and PFOS (_parse_params()) 
2. A method to get specific parameter vectors from the la_forge core (get_chain_params())
3. A rework of the pair covariance usage in linear solve which simplifies the use of the woodbury matrix lemma

Smaller changes include:
1. Better, clearer documentation on some of the methods used.
2. Fixed implementation of plotting functions
